### PR TITLE
Reduced log level of experimental/local opt codes

### DIFF
--- a/src/main/java/javax/jmdns/impl/DNSIncoming.java
+++ b/src/main/java/javax/jmdns/impl/DNSIncoming.java
@@ -431,7 +431,14 @@ public final class DNSIncoming extends DNSMessage {
                                 }
                                 break;
                             case Unknown:
-                                logger.log(Level.WARNING, "There was an OPT answer. Not currently handled. Option code: " + optionCodeInt + " data: " + this._hexString(optiondata));
+                                if (optionCodeInt >= 65001 && optionCodeInt <= 65534) {
+                                     // RFC 6891 defines this range as used for experimental/local purposes.
+                                    if (logger.isLoggable(Level.FINE)) {
+                                        logger.log(Level.FINE, "There was an OPT answer using an experimental/local option code: " + optionCodeInt + " data: " + this._hexString(optiondata));
+                                    }
+                                } else {
+                                    logger.log(Level.WARNING, "There was an OPT answer. Not currently handled. Option code: " + optionCodeInt + " data: " + this._hexString(optiondata));
+                                }
                                 break;
                             default:
                                 // This is to keep the compiler happy.


### PR DESCRIPTION
RFC 6891 identifies the range of OPT codes from 65001 to 65534 as used
for experimental/local purposes. Receipt of answers containing these
OPT codes is not cause for alarm, and can be safely ignored. Reducing
logging of the receipt of these answers to FINE instead of WARNING.
Other unrecognized codes outside this range will continue to WARN.
Fixes #12

Signed-off-by: Andy Lintner <dev@beowulfe.com> (github: beowulfe)