### PR TITLE
support "Legacy Unicast Responses"

### DIFF
--- a/src/main/java/javax/jmdns/impl/DNSOutgoing.java
+++ b/src/main/java/javax/jmdns/impl/DNSOutgoing.java
@@ -6,6 +6,7 @@ package javax.jmdns.impl;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -187,6 +188,8 @@ public final class DNSOutgoing extends DNSMessage {
 
     private final static int          HEADER_SIZE                 = 12;
 
+    private InetSocketAddress         _destination;
+
     /**
      * Create an outgoing multicast query or response.
      *
@@ -222,6 +225,24 @@ public final class DNSOutgoing extends DNSMessage {
         _answersBytes = new MessageOutputStream(senderUDPPayload, this);
         _authoritativeAnswersBytes = new MessageOutputStream(senderUDPPayload, this);
         _additionalsAnswersBytes = new MessageOutputStream(senderUDPPayload, this);
+    }
+
+    /**
+     * Get the forced destination address if a specific one was set.
+     *
+     * @return a forced destination address or null if no address is forced.
+     */
+    public InetSocketAddress getDestination() {
+        return _destination;
+    }
+
+    /**
+     * Force a specific destination address if packet is sent.
+     *
+     * @param destination Set a destination address a packet should be sent to (instead the default one). You could use null to unset the forced destination.
+     */
+    public void setDestination(InetSocketAddress destination) {
+        _destination = destination;
     }
 
     /**

--- a/src/main/java/javax/jmdns/impl/DNSTaskStarter.java
+++ b/src/main/java/javax/jmdns/impl/DNSTaskStarter.java
@@ -3,6 +3,7 @@
  */
 package javax.jmdns.impl;
 
+import java.net.InetAddress;
 import java.util.Date;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -390,8 +391,8 @@ public interface DNSTaskStarter {
          * @see javax.jmdns.impl.DNSTaskStarter#startResponder(javax.jmdns.impl.DNSIncoming, int)
          */
         @Override
-        public void startResponder(DNSIncoming in, int port) {
-            new Responder(_jmDNSImpl, in, port).start(_timer);
+        public void startResponder(DNSIncoming in, InetAddress addr, int port) {
+            new Responder(_jmDNSImpl, in, addr, port).start(_timer);
         }
     }
 
@@ -466,9 +467,11 @@ public interface DNSTaskStarter {
      *
      * @param in
      *            incoming message
+     * @param addr
+     *            incoming address
      * @param port
      *            incoming port
      */
-    public void startResponder(DNSIncoming in, int port);
+    public void startResponder(DNSIncoming in, InetAddress addr, int port);
 
 }

--- a/src/main/java/javax/jmdns/impl/JmDNSImpl.java
+++ b/src/main/java/javax/jmdns/impl/JmDNSImpl.java
@@ -1458,7 +1458,7 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
                 if (in.isTruncated()) {
                     _plannedAnswer = plannedAnswer;
                 }
-                this.startResponder(plannedAnswer, port);
+                this.startResponder(plannedAnswer, addr, port);
             }
 
         } finally {
@@ -1523,8 +1523,19 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
      */
     public void send(DNSOutgoing out) throws IOException {
         if (!out.isEmpty()) {
+            final InetAddress addr;
+            final int port;
+
+            if (out.getDestination() != null) {
+                addr = out.getDestination().getAddress();
+                port = out.getDestination().getPort();
+            } else {
+                addr = _group;
+                port = DNSConstants.MDNS_PORT;
+            }
+
             byte[] message = out.data();
-            final DatagramPacket packet = new DatagramPacket(message, message.length, _group, DNSConstants.MDNS_PORT);
+            final DatagramPacket packet = new DatagramPacket(message, message.length, addr, port);
 
             if (logger.isLoggable(Level.FINEST)) {
                 try {
@@ -1656,8 +1667,8 @@ public class JmDNSImpl extends JmDNS implements DNSStatefulObject, DNSTaskStarte
      * @see javax.jmdns.impl.DNSTaskStarter#startResponder(javax.jmdns.impl.DNSIncoming, int)
      */
     @Override
-    public void startResponder(DNSIncoming in, int port) {
-        DNSTaskStarter.Factory.getInstance().getStarter(this.getDns()).startResponder(in, port);
+    public void startResponder(DNSIncoming in, InetAddress addr, int port) {
+        DNSTaskStarter.Factory.getInstance().getStarter(this.getDns()).startResponder(in, addr, port);
     }
 
     // REMIND: Why is this not an anonymous inner class?

--- a/src/main/java/javax/jmdns/impl/tasks/Responder.java
+++ b/src/main/java/javax/jmdns/impl/tasks/Responder.java
@@ -4,6 +4,8 @@
 
 package javax.jmdns.impl.tasks;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.Timer;
@@ -29,13 +31,21 @@ public class Responder extends DNSTask {
     private final DNSIncoming _in;
 
     /**
+     * The incoming address and port.
+     */
+    private final InetAddress _addr;
+    private final int         _port;
+
+    /**
      *
      */
     private final boolean     _unicast;
 
-    public Responder(JmDNSImpl jmDNSImpl, DNSIncoming in, int port) {
+    public Responder(JmDNSImpl jmDNSImpl, DNSIncoming in, InetAddress addr, int port) {
         super(jmDNSImpl);
         this._in = in;
+        this._addr = addr;
+        this._port = port;
         this._unicast = (port != DNSConstants.MDNS_PORT);
     }
 
@@ -133,6 +143,9 @@ public class Responder extends DNSTask {
                         logger.finer(this.getName() + "run() JmDNS responding");
                     }
                     DNSOutgoing out = new DNSOutgoing(DNSConstants.FLAGS_QR_RESPONSE | DNSConstants.FLAGS_AA, !_unicast, _in.getSenderUDPPayload());
+                    if (_unicast) {
+                        out.setDestination(new InetSocketAddress(_addr, _port));
+                    }
                     out.setId(_in.getId());
                     for (DNSQuestion question : questions) {
                         if (question != null) {


### PR DESCRIPTION
Request for Comments: 6762
  (https://tools.ietf.org/html/rfc6762)
Multicast DNS
6.7.  Legacy Unicast Responses
   If the source UDP port in a received Multicast DNS query is not port
   5353, this indicates that the querier originating the query is a
   simple resolver such as described in Section 5.1, "One-Shot Multicast
   DNS Queries", which does not fully implement all of Multicast DNS.
   In this case, the Multicast DNS responder MUST send a UDP response
   directly back to the querier, via unicast, to the query packet's
   source IP address and port.

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>