### PR TITLE
Fixed handling of TXT records without '='

### DIFF
--- a/src/main/java/javax/jmdns/impl/ServiceInfoImpl.java
+++ b/src/main/java/javax/jmdns/impl/ServiceInfoImpl.java
@@ -862,8 +862,8 @@ public class ServiceInfoImpl extends ServiceInfo implements DNSListener, DNSStat
                         byte value[] = new byte[len - ++i];
                         System.arraycopy(getTextBytes(), off + i, value, 0, len - i);
                         properties.put(name, value);
-                        off += len;
                     }
+                    off += len;
                 }
             } catch (Exception exception) {
                 // We should get better logging.

--- a/src/test/java/javax/jmdns/test/ServiceInfoTest.java
+++ b/src/test/java/javax/jmdns/test/ServiceInfoTest.java
@@ -5,8 +5,11 @@ package javax.jmdns.test;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import javax.jmdns.ServiceInfo;
 import javax.jmdns.ServiceInfo.Fields;
@@ -225,6 +228,29 @@ public class ServiceInfoTest {
         service_info = ServiceInfo.create(service_type, service_name, service_port, 0, 0, true, properties); // case 3, properties assigned textual description
         assertEquals("We should have got the same properties (Map):", service_text, service_info.getPropertyString(service_key));
 
+    }
+
+    @Test
+    public void testDecodePropertiesWithoutEqualsSign() {
+        String service_type = "_ros-master._tcp.local.";
+        String service_name = "RosMaster";
+        int service_port = 8888;
+        ServiceInfo service_info = null;
+        // Represents TXT records "a" "b=c"
+        byte[] txt = {1, 97, 3, 98, 61, 99};
+        service_info = ServiceInfo.create(service_type, service_name, service_port, 0, 0, txt);
+
+        Set<String> expectedKeys = new HashSet<String>();
+        expectedKeys.add("a");
+        expectedKeys.add("b");
+
+        Enumeration<String> enumeration = service_info.getPropertyNames();
+        Set<String> keys = new HashSet<String>();
+        while (enumeration.hasMoreElements()) {
+            keys.add(enumeration.nextElement());
+        }
+        assertEquals(expectedKeys, keys);
+        assertEquals("c", service_info.getPropertyString("b"));
     }
 
 }


### PR DESCRIPTION
This commit fixes an issue with parsing TXT records without '=' in them.
The result of the issue is that the whole TXT record will be
considered invalid and the service will appear not have any properties
at all unless you use the raw byte array.

Signed-off-by: Mårten Borgström <martenborgstrom@gmail.com> (github: martenbr)