### PR TITLE
Fix building issues

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -58,9 +58,9 @@
 		</javac>
 	</target>
 
-	<target name="jar" depends="build,tools" description="Jar the files">
+	<target name="jar" depends="build" description="Jar the files">
 		<mkdir dir="${buildlib}" />
-		<jar destfile="${buildlib}/jmdns.jar" manifest="${lib}/jmdns.manifest" basedir="${dest}">
+		<jar destfile="${buildlib}/jmdns.jar" manifest="${lib}/jmdns.manifest">
 			<fileset dir="${dest}" defaultexcludes="yes">
 				<include name="**/*.class" />
 				<exclude name="**/test/*.class" />

--- a/src/main/java/javax/jmdns/impl/DNSCache.java
+++ b/src/main/java/javax/jmdns/impl/DNSCache.java
@@ -7,6 +7,7 @@ package javax.jmdns.impl;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -270,7 +271,9 @@ public class DNSCache extends ConcurrentHashMap<String, List<DNSEntry>> {
     public synchronized String toString() {
         StringBuffer aLog = new StringBuffer(2000);
         aLog.append("\t---- cache ----");
-        for (String key : this.keySet()) {
+        Enumeration<String> keyIter = this.keys();
+        while (keyIter.hasMoreElements()) {
+            String key = keyIter.nextElement();
             aLog.append("\n\t\t");
             aLog.append("\n\t\tname '");
             aLog.append(key);


### PR DESCRIPTION
Two things are addressed here:

1) "ant jar" works again by removing duplicate classes and old tools. It's probably no longer used, but FWIW.

2) JmDNS toString() does not crash anymore after building with Java 8, something similar to #17.

Signed-off-by: Eric Chen <taiyang.chen@gmail.com> (github: taiyangc)