### PR TITLE
Prevent unnecessary network traffic during cache cleanup, with test

### DIFF
--- a/src/main/java/javax/jmdns/impl/DNSRecord.java
+++ b/src/main/java/javax/jmdns/impl/DNSRecord.java
@@ -13,6 +13,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -33,6 +34,8 @@ public abstract class DNSRecord extends DNSEntry {
     private static Logger logger = Logger.getLogger(DNSRecord.class.getName());
     private int           _ttl;
     private long          _created;
+    private int           _isStaleAndShouldBeRefreshedPercentage;
+    private final int     _randomStaleRefreshOffset;
 
     /**
      * This source is mainly for debugging purposes, should be the address that sent this record.
@@ -46,6 +49,8 @@ public abstract class DNSRecord extends DNSEntry {
         super(name, type, recordClass, unique);
         this._ttl = ttl;
         this._created = System.currentTimeMillis();
+        _randomStaleRefreshOffset = new Random().nextInt(3);
+        _isStaleAndShouldBeRefreshedPercentage = DNSConstants.STALE_REFRESH_STARTING_PERCENTAGE + _randomStaleRefreshOffset;
     }
 
     /*
@@ -150,11 +155,33 @@ public abstract class DNSRecord extends DNSEntry {
     }
 
     /**
+     * Check if the record is stale and whether the record should be refreshed over the network.
+     *
+     * @param now
+     *            update date
+     * @return <code>true</code> is the record is stale and should be refreshed, <code>false</code> otherwise.
+     */
+    public boolean isStaleAndShouldBeRefreshed(long now) {
+        return getExpirationTime(_isStaleAndShouldBeRefreshedPercentage) <= now;
+    }
+
+    /*
+    * Increment the percentage that determines whether a record needs to be refreshed.
+     */
+    public void incrementRefreshPercentage() {
+        _isStaleAndShouldBeRefreshedPercentage += DNSConstants.STALE_REFRESH_INCREMENT;
+        if (_isStaleAndShouldBeRefreshedPercentage > 100) {
+            _isStaleAndShouldBeRefreshedPercentage = 100;
+        }
+    }
+
+    /**
      * Reset the TTL of a record. This avoids having to update the entire record in the cache.
      */
     void resetTTL(DNSRecord other) {
         _created = other._created;
         _ttl = other._ttl;
+        _isStaleAndShouldBeRefreshedPercentage = DNSConstants.STALE_REFRESH_STARTING_PERCENTAGE + _randomStaleRefreshOffset;
     }
 
     /**

--- a/src/main/java/javax/jmdns/impl/constants/DNSConstants.java
+++ b/src/main/java/javax/jmdns/impl/constants/DNSConstants.java
@@ -54,6 +54,9 @@ public final class DNSConstants {
     public static final int    KNOWN_ANSWER_TTL               = 120;
     public static final int    ANNOUNCED_RENEWAL_TTL_INTERVAL = DNS_TTL * 500;                                                // 50% of the TTL in milliseconds
 
+    public static final int    STALE_REFRESH_INCREMENT           = 5;
+    public static final int    STALE_REFRESH_STARTING_PERCENTAGE = 80;
+
     public static final long   CLOSE_TIMEOUT                  = ANNOUNCE_WAIT_INTERVAL * 5L;
     public static final long   SERVICE_INFO_TIMEOUT           = ANNOUNCE_WAIT_INTERVAL * 6L;
 

--- a/src/test/java/javax/jmdns/test/DNSRecordTest.java
+++ b/src/test/java/javax/jmdns/test/DNSRecordTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 JmDNS.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package javax.jmdns.test;
+
+import javax.jmdns.impl.DNSRecord;
+import javax.jmdns.impl.constants.DNSRecordClass;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DNSRecordTest {
+
+    private static final int TTL_IN_SECONDS = 60 * 60; // ONE HOUR
+    private static final long ONE_HOUR_IN_MILLIS = 60 * 60 * 1000;
+    private static final long PERCENT_STALE_79 = ONE_HOUR_IN_MILLIS * 79 / 100;
+    private static final long PERCENT_STALE_84 = ONE_HOUR_IN_MILLIS * 84 / 100;
+    private static final long PERCENT_STALE_89 = ONE_HOUR_IN_MILLIS * 89 / 100;
+    private static final long PERCENT_STALE_94 = ONE_HOUR_IN_MILLIS * 94 / 100;
+    private static final long PERCENT_STALE_99 = ONE_HOUR_IN_MILLIS * 99 / 100;
+
+    @Test
+    public void testStaleDNSRecord() {
+
+        DNSRecord record = new DNSRecord.Service("test", DNSRecordClass.CLASS_IN, true, TTL_IN_SECONDS, 0, 0, 0, "test");
+        long now = System.currentTimeMillis();
+
+        // stale threshold is 80% + random offset
+        Assert.assertFalse("Record should not be stale after creation", record.isStaleAndShouldBeRefreshed(now));
+        Assert.assertFalse("79% should not be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_79));
+        Assert.assertTrue("84% should be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_84));
+
+        // stale threshold is 85% + random offset
+        record.incrementRefreshPercentage();
+        Assert.assertFalse("84% should not be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_84));
+        Assert.assertTrue("89% should be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_89));
+
+        // stale threshold is 90% + random offset
+        record.incrementRefreshPercentage();
+        Assert.assertFalse("89% should not be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_89));
+        Assert.assertTrue("94% should be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_94));
+
+        // stale threshold is 95% + random offset
+        record.incrementRefreshPercentage();
+        Assert.assertFalse("94% should not be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_94));
+        Assert.assertTrue("99% should be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_99));
+
+        // stale threshold is 100%
+        record.incrementRefreshPercentage();
+        Assert.assertFalse("99% should not be stale", record.isStaleAndShouldBeRefreshed(now + PERCENT_STALE_99));
+        Assert.assertTrue("100% should be stale", record.isStaleAndShouldBeRefreshed(now + ONE_HOUR_IN_MILLIS));
+
+    }
+
+}


### PR DESCRIPTION
Signed-off-by: Carsten <carsten@meyermuc.de>

We'd like to conritubte an enhancement that we recently implemented because we encountered the following problem:

In our environment there a a lot of service instances (for the same service type, >30) and a lot of listeners for these service (> 20). Under certain circumstances we saw MDNS traffic on our network exceeding 1 MB/s (caused by our services).

Close investigation revealed the following:
Since some of service instances were sometimes not shutdown correctly (no "Goodbye"-Packets), these remained in the cache of all the listeners. During cache cleanup (every 10s) each listener would try to renew this service once the TTL of this record is less than 50% of its original value (60 min).

This leads to the following behaviour:
After 30 min, every listener would query every 10 s for the service type of the stale record and never receive an answer from this record (and therefore never resetting the TTL). But every available service instance would answer every query from every listener nonetheless....
So we have about 20 listeners asking every 10 s with more than 30 service instances answering until the TTL of the stale/dead record has elapsed. Additionally, we've seen multiple network request for a single service type in each refresh cycle, which also adds network load because every request is answered by all available services.

This seemed to be the cause of the above mentioned network flooding.

According to the RFC in section 5.2 the following behaviour should be implemented:

>To perform this cache maintenance, a Multicast DNS querier should
>plan to retransmit its query after at least 50% of the record
>lifetime has elapsed. This document recommends the following
>specific strategy.
>
>The querier should plan to issue a query at 80% of the record
>lifetime, and then if no answer is received, at 85%, 90%, and 95%.
>If an answer is received, then the remaining TTL is reset to the
>value given in the answer, and this process repeats for as long as
>the Multicast DNS querier has an ongoing interest in the record. If
>no answer is received after four queries, the record is deleted when
>it reaches 100% of its lifetime. A Multicast DNS querier MUST NOT
>perform this cache maintenance for records for which it has no local
>clients with an active interest. If the expiry of a particular
>record from the cache would result in no net effect to any client
>software running on the querier device, and no visible effect to the
>human user, then there is no reason for the Multicast DNS querier to
>waste network capacity checking whether the record remains valid.
>
>To avoid the case where multiple Multicast DNS queriers on a network
>all issue their queries simultaneously, a random variation of 2% of
>the record TTL should be added, so that queries are scheduled to be
>performed at 80-82%, 85-87%, 90-92%, and then 95-97% of the TTL."

This pull request contains our implementation of this behaviour.
We are looking forward to your review.
Thanks again! :)